### PR TITLE
Update cloud sdk

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -41,14 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        switch url.host {
-        case "redirect":
-            AppKit.handleRedirectURL(url)
-            return true
-
-        default:
-            return false
-        }
+        return PACECloudSDK.shared.application(open: url)
     }
 
     private func applyGlobalTheme() {

--- a/App/Sources/SceneDelegate.swift
+++ b/App/Sources/SceneDelegate.swift
@@ -1,4 +1,5 @@
 import JLCoordinator
+import PACECloudSDK
 import UIKit
 
 @available(iOS 13.0, *)
@@ -14,5 +15,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         initialCoordinator = .init(presenter: InitialPresenter(window: .init(windowScene: windowScene)))
         initialCoordinator?.start()
+    }
+
+    func scene(_ scene: UIScene,
+               openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else {
+            return
+        }
+        let _ = UIApplication.shared.delegate?.application?(UIApplication.shared, open: url)
     }
 }

--- a/ConnectedFueling.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ConnectedFueling.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/pace/cloud-sdk-ios",
         "state": {
           "branch": null,
-          "revision": "7169827f8af6e91c3e989f2751acf17b759f2572",
-          "version": "9.0.0"
+          "revision": "eda667995fb03ffb974a718df2500da29c3a6063",
+          "version": "9.2.1"
         }
       },
       {


### PR DESCRIPTION
Updates the cloud SDK version and fixes a bug where the app would not handle redirect URLs correctly for iOS >= `13.0` because the needed methods were not implemented in the `SceneDelegate`.

Closes #5 