### PR TITLE
Fix move AppKitDelegate to AppDelegate

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
 
         applyGlobalTheme()
+        AppKit.delegate = self
 
         if #available(iOS 13.0, *) {
             // NOTE: If iOS 13 is available SceneDelegate will be used to initialize the view
@@ -54,4 +55,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         navigationBar.tintColor = .white
         navigationBar.setTitleVerticalPositionAdjustment(0, for: .default)
     }
+}
+
+extension AppDelegate: AppKitDelegate {
+    func didFail(with error: AppKit.AppError) {}
+    func didReceiveAppDrawers(_ appDrawers: [AppKit.AppDrawer], _ appDatas: [AppKit.AppData]) {}
 }

--- a/App/Sources/Coordinators/PaymentHistory/PaymentHistoryCoordinator.swift
+++ b/App/Sources/Coordinators/PaymentHistory/PaymentHistoryCoordinator.swift
@@ -3,11 +3,10 @@ import JLCoordinator
 import PACECloudSDK
 import UIKit
 
-final class PaymentHistoryCoordinator: Coordinator, AppKitDelegate {
+final class PaymentHistoryCoordinator: Coordinator {
     typealias Callback = () -> Void
 
     private let callback: Callback?
-    private var appKitDelegate: AppKitDelegate? // swiftlint:disable:this weak_delegate
     private lazy var viewController: AppViewController = AppKit.appViewController(
         presetUrl: .transactions,
         isModalInPresentation: false,
@@ -22,20 +21,5 @@ final class PaymentHistoryCoordinator: Coordinator, AppKitDelegate {
 
     override func start() {
         presenter.present(viewController, animated: true)
-        appKitDelegate = AppKit.delegate
-        AppKit.delegate = self
-    }
-
-    override func stop() {
-        AppKit.delegate = appKitDelegate
-        appKitDelegate = nil
-    }
-
-    func didFail(with error: AppKit.AppError) {
-        // Add error handling
-    }
-
-    func didReceiveAppDrawers(_ appDrawers: [AppKit.AppDrawer], _ appDatas: [AppKit.AppData]) {
-        // Add handling for app drawers
     }
 }


### PR DESCRIPTION
Remove `AppKitDelegate` from `PaymentHistoryCoordinator` and move it to the `AppDelegate`.

Closes #7 