### PR TITLE
Fix wrong navigation bar color in iOS 15

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -44,8 +44,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         view.tintColor = Asset.Colors.Theme.primary.color
 
         let navigationBar = UINavigationBar.appearance()
-        navigationBar.isTranslucent = false
-        navigationBar.barTintColor = Asset.Colors.Theme.primary.color
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = Asset.Colors.Theme.primary.color
+            navigationBar.standardAppearance = appearance
+            navigationBar.scrollEdgeAppearance = navigationBar.standardAppearance
+        } else {
+            navigationBar.isTranslucent = false
+            navigationBar.barTintColor = Asset.Colors.Theme.primary.color
+        }
         navigationBar.tintColor = .white
         navigationBar.setTitleVerticalPositionAdjustment(0, for: .default)
     }


### PR DESCRIPTION
Use the new appearance API for the global navigation bar appearance for `iOS >= 13` 

Closes #10 